### PR TITLE
Remove "linux" special case when using zip

### DIFF
--- a/tools/util/util.js
+++ b/tools/util/util.js
@@ -13,10 +13,10 @@ var util = {
 	},
 	zip: {
 		folder: function (targetfile, sourcefolder, folder = "*") {
-			if (process.platform === 'linux') {
-				util.spawn.sync("zip -r --quiet --recurse-paths " + targetfile + " " + folder, sourcefolder);
-				return;
-			}
+			// if (process.platform === 'linux') {
+			// 	util.spawn.sync("zip -r --quiet --recurse-paths " + targetfile + " " + folder, sourcefolder);
+			// 	return;
+			// }
 			util.spawn.sync("bestzip " + targetfile + " " + folder, sourcefolder);
 		}
   },

--- a/tools/util/util.js
+++ b/tools/util/util.js
@@ -13,10 +13,6 @@ var util = {
 	},
 	zip: {
 		folder: function (targetfile, sourcefolder, folder = "*") {
-			// if (process.platform === 'linux') {
-			// 	util.spawn.sync("zip -r --quiet --recurse-paths " + targetfile + " " + folder, sourcefolder);
-			// 	return;
-			// }
 			util.spawn.sync("bestzip " + targetfile + " " + folder, sourcefolder);
 		}
   },


### PR DESCRIPTION
The "bestzip" package will already use the native zip, if available. Inside a docker container (node.js), zip may actually not be available, but bestzip still works in this case. 